### PR TITLE
Add get and delete CLI subcommands with handlers

### DIFF
--- a/vault/src/cli.rs
+++ b/vault/src/cli.rs
@@ -8,6 +8,12 @@ pub enum CliCommand {
         password: String,
     },
     List,
+    Get {
+        service: String,
+    },
+    Delete {
+        service: String,
+    },
 }
 
 pub fn parse_cli () -> CliCommand {
@@ -32,6 +38,22 @@ pub fn parse_cli () -> CliCommand {
         }
         "list" => CliCommand::List,
 
+        "get" => {
+            if args.len() != 3 {
+                panic!("Usage: vault get <service>");
+            }
+            CliCommand::Get {
+                service: args[2].clone(),
+            }
+        }
+        "delete" => {
+            if args.len() != 3 {
+                panic!("Usage: vault delete <service>");
+            }
+            CliCommand::Delete {
+                service: args[2].clone(),
+            }
+        }
 
         _ => panic! ("Unknown command")
     }

--- a/vault/src/commands/delete.rs
+++ b/vault/src/commands/delete.rs
@@ -1,0 +1,13 @@
+use crate::core::vault_format;
+use crate::storage::file_io;
+
+pub fn execute(service: String) {
+    let mut vault = file_io::load_vault().expect("Failed to load vault");
+
+    if vault_format::delete_entry(&mut vault, &service) {
+        file_io::save_vault(&vault).expect("Failed to save vault");
+        println!("Entry for service '{}' deleted successfully", service);
+    } else {
+        eprintln!("Error: No entry found for service '{}'", service);
+    }
+}

--- a/vault/src/commands/get.rs
+++ b/vault/src/commands/get.rs
@@ -1,0 +1,14 @@
+use crate::core::vault_format;
+use crate::storage::file_io;
+
+pub fn execute(service: String) {
+    let vault = file_io::load_vault().expect("Failed to load vault");
+
+    if let Some(entry) = vault_format::get_entry(&vault, &service) {
+        println!("Service: {}", entry.service);
+        println!("Username: {}", entry.username);
+        println!("Password: {}", entry.password);
+    } else {
+        eprintln!("Error: No entry found for service '{}'", service);
+    }
+}

--- a/vault/src/core/vault_format.rs
+++ b/vault/src/core/vault_format.rs
@@ -19,3 +19,16 @@ pub fn add_entry(vault: &mut Vault, service: String, username: String, password:
 pub fn list_entries(vault: &Vault) ->&[Credential]{
     &vault.entries
 }
+
+pub fn get_entry<'a>(vault: &'a Vault, service: &str) -> Option<&'a Credential> {
+    vault.entries.iter().find(|entry| entry.service == service)
+}
+
+pub fn delete_entry(vault: &mut Vault, service: &str) -> bool {
+    if let Some(pos) = vault.entries.iter().position(|entry| entry.service == service) {
+        vault.entries.remove(pos);
+        true
+    } else {
+        false
+    }
+}

--- a/vault/src/main.rs
+++ b/vault/src/main.rs
@@ -17,5 +17,11 @@ fn main() {
         CliCommand::List =>{
             commands::list::execute();
         }
+        CliCommand::Get {service} =>{
+            commands::get::execute(service);
+        }
+        CliCommand::Delete {service} =>{
+            commands::delete::execute(service);
+        }
     }
 }


### PR DESCRIPTION
Completed issue #7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now retrieve and display stored credentials using the `get` command by specifying a service name, which shows the associated username and password.
  * Users can now delete password entries from their vault using the `delete` command by service name, providing more control over stored credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->